### PR TITLE
Remove hardcoded page types

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ blog2.Blog2 = function(options, callback) {
     indexesOptions.addFields = [
       {
         name: '_andFromPages',
-        label: 'And From These Blogs',
+        label: 'And From These ' + self.pluralIndexLabel,
         type: 'joinByArray',
         idsField: 'andFromPagesIds',
         relationship: [
@@ -111,7 +111,7 @@ blog2.Blog2 = function(options, callback) {
           }
         ],
         relationshipsField: 'andFromPagesRelationships',
-        withType: 'blog'
+        withType: self.indexName
       }
     ].concat(indexesOptions.addFields || []);
 
@@ -527,8 +527,8 @@ blog2.Blog2 = function(options, callback) {
       {
         name: '_parent',
         type: 'joinByOne',
-        label: 'Move to Another Blog',
-        placeholder: 'Type the name of the blog',
+        label: 'Move to Another ' + self.indexLabel,
+        placeholder: 'Type the name of the ' + self.indexLabel.toLowerCase(),
         withType: self.indexName,
         idField: '_newParentId',
         getOptions: {


### PR DESCRIPTION
I was trying to extend this module, but I've got errors, because there was hardcoded  `withType: 'blog'`. 
